### PR TITLE
debugStepperCount

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -329,7 +329,7 @@
 
 
 
-
+<!-- CONTINUE HERE -->
 <!-- SELECT / START ------------------------------------------------------------------------------>
 <!-- <select id="source">
   <option value="BR" selected="selected">Brasil</option>

--- a/src/index.html
+++ b/src/index.html
@@ -329,7 +329,7 @@
 
 
 
-
+<!-- CONTINUE HERE -->
 <!-- SELECT / START ------------------------------------------------------------------------------>
 <!-- <select id="source">
   <option value="BR" selected="selected">Brasil</option>

--- a/src/js/eventFunctions.js
+++ b/src/js/eventFunctions.js
@@ -10,7 +10,7 @@ class EventFunctions {
     const stepperAdd = () => {
       const minValid = +input.value >= +input.min;
       const maxValid = +input.value < +input.max;
-      if (minValid && maxValid) input.value += 1;
+      if (minValid && maxValid) input.value = +input.value + 1;
       if (+input.value === +input.max) {
         wrapper.querySelector('.notice').textContent = 'Max. value';
         wrapper.querySelector('.notice').classList.add('active');
@@ -19,7 +19,7 @@ class EventFunctions {
     const stepperMinus = () => {
       const minValid = +input.value > +input.min;
       const maxValid = +input.value <= +input.max;
-      if (minValid && maxValid) input.value -= 1;
+      if (minValid && maxValid) input.value = +input.value - 1;
       if (+input.value === +input.min) {
         wrapper.querySelector('.notice').textContent = 'Min. value';
         wrapper.querySelector('.notice').classList.add('active');


### PR DESCRIPTION
- debugStepperCount Complete
- Unary operator was caught on eslint
- Used 'input.value =+ 1' which is wrong since value needs to be converted to integer
- '+input.value =+ 1' is a left-hand assignement error since =+ is an assignment operator.
- Used 'input.value = +input/value + 1'
- BACKLOG: CSS Pseudo Select, CSS Pseudo Multi-Select, Number Slider